### PR TITLE
[codex] add pnpm release age guard

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 10080


### PR DESCRIPTION
## What changed

Added `pnpm-workspace.yaml` with `minimumReleaseAge: 10080`.

## Why

This makes pnpm avoid newly published package versions until they have aged for 7 days, reducing exposure to compromised or accidentally broken fresh releases.

## Impact

Future pnpm installs and dependency updates in this workspace will respect the release age guard.

## Validation

- Confirmed `pnpm config get minimum-release-age` returns `10080`.
- Verified the staged diff only adds `pnpm-workspace.yaml` with the requested setting.